### PR TITLE
[mobile-broadband-provider-info] Fixed settings for Telenor Norway

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -9359,26 +9359,12 @@ conceived.
 				<dns>212.17.131.3</dns>
 				<dns>148.122.161.2</dns>
 			</apn>
-			<apn value="mms.ventelo.no">
-				<usage type="mms"/>
-				<name>Ludo MMS</name>
-				<username>ventelo</username>
-				<password>1111</password>
-				<mmsc>http://mmsc/</mmsc>
-				<mmsproxy>10.10.10.11:8080</mmsproxy>
-			</apn>
-			<apn value="mms">
-				<usage type="mms"/>
-				<name>Telenor MMS</name>
-				<mmsc>http://mmsc/</mmsc>
-				<mmsproxy>10.10.10.11:8080</mmsproxy>
-			</apn>
 			<apn value="telenor">
 				<usage type="mms"/>
-				<name>Mobitalk MMS</name>
+				<name>Telenor MMS</name>
 				<username>dj</username>
 				<password>dj</password>
-				<mmsc>http://mmsc/</mmsc>
+				<mmsc>http://mmsc</mmsc>
 				<mmsproxy>10.10.10.11:8080</mmsproxy>
 			</apn>
 		</gsm>
@@ -9454,6 +9440,14 @@ conceived.
 			<apn value="internet.ventelo.no">
 				<plan type="postpaid"/>
 				<usage type="internet"/>
+			</apn>
+			<apn value="mms.ventelo.no">
+				<usage type="mms"/>
+				<name>Ventelo MMS</name>
+				<username>ventelo</username>
+				<password>1111</password>
+				<mmsc>http://mmsc/</mmsc>
+				<mmsproxy>10.10.10.11:8080</mmsproxy>
 			</apn>
 		</gsm>
 	</provider>


### PR DESCRIPTION
Ventelo settings were being selected for Telenor customers:

http://www.telenor.no/privat/kundeservice/mobilhjelp/internettpamobilen/
http://www.ventelo.no/bedrift/kundeservice/mobil/oppsett/manuelt-oppsett/

It appears that both Telenor and Ventelo use mcc="242" mnc="01" but
- According to wikipedia it's Telenor's MCC/MNC
- Telenor is bigger

So let's fix it for Telenor customers and let those Ventelo customers with 242/01 enter MMS settings manually. That's the best we can do in the moment.
