### PR TITLE
[mbpi] Updated MMS settings for MTel (Bulgaria)

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -1470,10 +1470,10 @@ conceived.
 			<apn value="mms-gprs.mtel.bg">
 				<usage type="mms"/>
 				<name>MobiTel BG MMS</name>
-				<username>Mtel</username>
-				<password>Mtel</password>
-				<mmsc>http://mmsc/</mmsc>
-				<mmsproxy>10.150.0.22:9201</mmsproxy>
+				<username>mtel</username>
+				<password>mtel</password>
+				<mmsc>http://mmsc</mmsc>
+				<mmsproxy>10.150.0.33:8080</mmsproxy>
 			</apn>
 		</gsm>
 	</provider>


### PR DESCRIPTION
Customers are confused, especially by the fact that this operator tells its customers to use 010.150.000.033 as MMS proxy IP address which we interpret as 8.150.0.27
