### PR TITLE
[mbpi] Fix Aina.com MVNO settings

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -4335,16 +4335,32 @@ conceived.
 	<provider>
 		<name>Aina</name>
 		<gsm>
-			<network-id mcc="244" mnc="04"/>
+			<network-id mcc="244" mnc="12"/>
 			<apn value="internet.aina.fi">
 				<usage type="internet"/>
-				<name>Internet</name>
+				<name>Aina Web</name>
 			</apn>
 			<apn value="mms.aina.fi">
 				<usage type="mms"/>
-				<name>MMS</name>
+				<name>Aina MMS</name>
 				<mmsc>http://mmsc.aina.fi</mmsc>
 				<mmsproxy>10.1.10.2:8080</mmsproxy>
+			</apn>
+		</gsm>
+	</provider>
+	<provider>
+		<name>Aina</name>
+		<gsm>
+			<network-id mcc="244" mnc="91"/>
+			<apn value="internet.aina.fi">
+				<usage type="internet"/>
+				<name>Aina Web</name>
+			</apn>
+			<apn value="mms.aina.fi">
+				<usage type="mms"/>
+				<name>Aina MMS</name>
+				<mmsc>http://mms.sonera.fi:8002</mmsc>
+				<mmsproxy>195.156.25.33:8080</mmsproxy>
 			</apn>
 		</gsm>
 	</provider>


### PR DESCRIPTION
Settings updated based on end user and Aina.com feedback.
(At http://www.ainacom.fi/asetukset/asetukset-manuaalisesti Android MNC=91 section MMS port "80" is probably incorrect, iPhone/Lumia sections as well as initial Aina.com response use 8002)
