### PR TITLE
Orange Austria is no more

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -487,83 +487,14 @@ conceived.
 		</gsm>
 	</provider>
 	<provider>
-		<name>Orange</name>
-		<gsm>
-			<network-id mcc="232" mnc="05"/>
-			<apn value="web.one.at">
-				<plan type="postpaid"/>
-				<usage type="internet"/>
-				<name>OneNet Web</name>
-				<username>web</username>
-				<password>web</password>
-				<dns>194.24.128.100</dns>
-				<dns>194.24.128.102</dns>
-			</apn>
-			<apn value="wap.one.at">
-				<plan type="postpaid"/>
-				<usage type="wap"/>
-				<name>Orange WAP</name>
-				<username>wap</username>
-				<password>wap</password>
-			</apn>
-			<apn value="mms.one.at">
-				<plan type="postpaid"/>
-				<usage type="mms"/>
-				<name>Orange MMS</name>
-				<username>mms</username>
-				<password>mms</password>
-			</apn>
-			<apn value="fullspeed">
-				<plan type="postpaid"/>
-				<usage type="internet"/>
-				<name>Web (no filtering)</name>
-				<username>web</username>
-				<password>web</password>
-			</apn>
-			<apn value="orange.web">
-				<plan type="postpaid"/>
-				<usage type="internet"/>
-				<name>Orange Web</name>
-				<username>Orange</username>
-				<password>Orange</password>
-				<dns>81.3.216.100</dns>
-				<dns>194.24.128.100</dns>
-			</apn>
-			<apn value="orange.mms">
-				<plan type="postpaid"/>
-				<usage type="mms"/>
-				<name>Orange Web</name>
-				<username>mms</username>
-				<password>mms</password>
-			</apn>
-			<apn value="mms.one.at">
-				<usage type="mms"/>
-				<name>Orange AT-MMS</name>
-				<username>mms</username>
-				<password>mms</password>
-				<mmsc>http://mmsc.one.at/mms/wapenc</mmsc>
-				<mmsproxy>194.24.128.118:8080</mmsproxy>
-			</apn>
-			<apn value="orange.mms">
-				<usage type="mms"/>
-				<name>Orange MMS</name>
-				<username>mms</username>
-				<password>mms</password>
-				<mmsc>http://mmsc.orange.at/mms/wapenc</mmsc>
-				<mmsproxy>194.24.128.118:8080</mmsproxy>
-			</apn>
-		</gsm>
-	</provider>
-	<provider>
 		<name>Drei (3)</name>
 		<name xml:lang="de">Drei</name>
 		<gsm>
+			<network-id mcc="232" mnc="05"/>
 			<network-id mcc="232" mnc="10"/>
 			<apn value="drei.at">
-				<plan type="postpaid"/>
 				<usage type="internet"/>
-				<dns>213.94.78.17</dns>
-				<dns>213.94.78.16</dns>
+				<name>Planet3</name>
 			</apn>
 			<apn value="drei.at">
 				<usage type="mms"/>


### PR DESCRIPTION
Confirmed with the actual customer that 232/05 sim cards only work with Drei (3) settings these days:

https://www.drei.at/portal/de/bottomnavi/kontakt-und-hilfe/technischer-support/einstellungen/