### PR TITLE
no: New default APN for Telenor Norway

### DIFF
--- a/mobile-broadband-provider-info/serviceproviders.xml
+++ b/mobile-broadband-provider-info/serviceproviders.xml
@@ -9368,17 +9368,14 @@ conceived.
 				<sms text="saldo">2525</sms>
 			</balance-check>
 
-			<apn value="telenor">
+			<apn value="telenor.smart">
 				<plan type="postpaid"/>
 				<usage type="internet"/>
-				<dns>212.17.131.3</dns>
-				<dns>148.122.161.2</dns>
+				<name>Telenor</name>
 			</apn>
-			<apn value="telenor">
+			<apn value="telenor.smart">
 				<usage type="mms"/>
 				<name>Telenor MMS</name>
-				<username>dj</username>
-				<password>dj</password>
 				<mmsc>http://mmsc</mmsc>
 				<mmsproxy>10.10.10.11:8080</mmsproxy>
 			</apn>


### PR DESCRIPTION
Telenor Norway's new APN is "telenor.smart". This APN supports both IPv4
and IPv6, so it is necessary to use a hostname rather than a literal
IPv4 address for the MMS proxy setting. Also remove the statically
configured DNS servers; Telenor is using dynamic DNS server assignment
(and the DNS servers they currently assign are in any case different
from the ones currently hard-coded in serviceproviders.xml).

This change has been ACK-ed by Telenor's IPv6 project leader
Gwenael-Christian Berthet <Gwenael-Christian.Berthet@telenor.com>.

The new settings may be verified on Telenor's web pages at
http://www.telenor.no/privat/kundeservice/mobilhjelp/ (under "Kom i gang
med IPv6").